### PR TITLE
Make V2 API work standalone without V1 credentials

### DIFF
--- a/api.js
+++ b/api.js
@@ -5,7 +5,14 @@ const ProtectWebClient = require('./library/webclient');
 
 module.exports = {
     async getStatus({homey, query}) {
-        return homey.app.api.loggedInStatus;
+        // Return status based on which API is available
+        if (homey.app.isV1Available()) {
+            return homey.app.api.loggedInStatus;
+        }
+        if (homey.app.isV2Available()) {
+            return homey.app.apiV2.loggedInStatus || 'Connected (V2)';
+        }
+        return homey.app.api.loggedInStatus || 'Not configured';
     },
     async getWebsocketStatus({homey, query}) {
         return homey.app.api.ws.isWebsocketConnected() ? 'Connected' : 'Unknown';
@@ -36,67 +43,137 @@ module.exports = {
         return homey.app.apiV2.websocket.getLastWebsocketMessageTime();
     },
     async testCredentials({homey, body}) {
+        // Test V1 (username/password) credentials
+        if (body.user && body.pass) {
+            try {
+                return new Promise((resolve, reject) => {
+                    const credentials = JSON.stringify({
+                        username: body.user,
+                        password: body.pass,
+                    });
+
+                    const options = {
+                        method: 'POST',
+                        hostname: body.host,
+                        port: body.port,
+                        path: '/api/auth/login',
+                        headers: {
+                            'Content-Type': 'application/json; charset=utf-8',
+                            Accept: 'application/json',
+                        },
+                        maxRedirects: 20,
+                        rejectUnauthorized: false,
+                        timeout: 2000,
+                        keepAlive: true,
+                    };
+
+                    const req = https.request(options, (res) => {
+                        if (res.statusCode === 401) {
+                            reject(new Error('Invalid credentials (401)'));
+                            return;
+                        }
+                        if (res.statusCode === 403) {
+                            reject(new Error('Invalid credentials (403)'));
+                            return;
+                        }
+                        if (res.statusCode === 429) {
+                            reject(new Error('Invalid credentials (429 - Too many attempts, please wait)'));
+                            return;
+                        }
+                        if (res.statusCode !== 200) {
+                            reject(new Error(`Invalid credentials (${res.statusCode})`));
+                            return;
+                        }
+                        const body = [];
+
+                        res.on('data', (chunk) => body.push(chunk));
+                        resolve('Valid credentials');
+                    });
+
+                    req.on('error', (error) => {
+                        reject(new Error(`Invalid credentials (${error.message})`));
+                    });
+
+                    req.write(credentials);
+                    req.end();
+                }).then((result) => {
+                    return {
+                        status: 'success',
+                        message: 'V1 credentials valid',
+                    };
+                }).catch((error) => {
+                    return {
+                        status: 'failure',
+                        error,
+                    };
+                });
+            } catch (error) {
+                homey.log('testCredentials error', error);
+                return {
+                    status: 'failure',
+                    error: error.message,
+                };
+            }
+        }
+
+        // If no V1 credentials, test V2 API key
+        if (body.protectV2ApiKey) {
+            return this.testV2ApiKey({homey, body});
+        }
+
+        return {
+            status: 'failure',
+            error: 'No credentials or API key provided',
+        };
+    },
+    async testV2ApiKey({homey, body}) {
         try {
             return new Promise((resolve, reject) => {
-                this.webclient = new ProtectWebClient();
-                this.webclient.setServerHost(body.host);
-                this.webclient.setServerPort(body.port);
-
-                // homey.app.api.getCSRFToken(body.host, body.port).then(response => {
-                const credentials = JSON.stringify({
-                    username: body.user,
-                    password: body.pass,
-                });
-
                 const options = {
-                    method: 'POST',
+                    method: 'GET',
                     hostname: body.host,
-                    port: body.port,
-                    path: '/api/auth/login',
+                    port: body.port || 443,
+                    path: '/proxy/protect/integration/v1/cameras',
                     headers: {
                         'Content-Type': 'application/json; charset=utf-8',
-                        Accept: 'application/json',
+                        Accept: '*/*',
+                        'X-API-KEY': body.protectV2ApiKey,
                     },
                     maxRedirects: 20,
                     rejectUnauthorized: false,
-                    timeout: 2000,
+                    timeout: 5000,
                     keepAlive: true,
                 };
 
                 const req = https.request(options, (res) => {
-                    if (res.statusCode === 401) {
-                        reject(new Error('Invalid credentials (401)'));
-                        return;
-                    }
-                    if (res.statusCode === 403) {
-                        reject(new Error('Invalid credentials (403)'));
-                        return;
-                    }
-                    // 429
-                    if (res.statusCode === 429) {
-                        reject(new Error('Invalid credentials (429 - Too many attempts, please wait)'));
-                        return;
-                    }
-                    if (res.statusCode !== 200) {
-                        reject(new Error(`Invalid credentials (${res.statusCode})`));
-                        return;
-                    }
-                    const body = [];
-
-                    res.on('data', (chunk) => body.push(chunk));
-                    resolve('Valid credentials');
+                    const data = [];
+                    res.on('data', (chunk) => data.push(chunk));
+                    res.on('end', () => {
+                        if (res.statusCode === 401) {
+                            reject(new Error('Invalid API key (401)'));
+                            return;
+                        }
+                        if (res.statusCode === 403) {
+                            reject(new Error('Invalid API key (403)'));
+                            return;
+                        }
+                        if (res.statusCode !== 200) {
+                            reject(new Error(`API key test failed (${res.statusCode})`));
+                            return;
+                        }
+                        resolve('Valid V2 API key');
+                    });
                 });
 
                 req.on('error', (error) => {
-                    reject(new Error(`Invalid credentials (${error.message})`));
+                    reject(new Error(`V2 API key test failed (${error.message})`));
                 });
 
-                req.write(credentials);
                 req.end();
-                // });
             }).then((result) => {
                 return {
                     status: 'success',
+                    message: 'V2 API key valid',
                 };
             }).catch((error) => {
                 return {
@@ -105,7 +182,7 @@ module.exports = {
                 };
             });
         } catch (error) {
-            homey.log('testCredentials error', error);
+            homey.log('testV2ApiKey error', error);
             return {
                 status: 'failure',
                 error: error.message,

--- a/app.js
+++ b/app.js
@@ -98,7 +98,12 @@ class UniFiProtect extends Homey.App {
             this.appProtect.loginToProtectV2().catch(this.error);
         }
 
-        this.appProtect._appLogin();
+        // Only attempt V1 login if credentials (username/password) are configured
+        const credentials = this.homey.settings.get('ufp:credentials');
+        if (credentials && credentials.username && credentials.password) {
+            this.appProtect._appLogin();
+        }
+
         // refresh auth tokens every hour
         await this.appProtect.refreshAuthTokens();
 
@@ -148,6 +153,20 @@ class UniFiProtect extends Homey.App {
             }
 
         }
+    }
+
+    /**
+     * Check if V1 API (username/password) is logged in and available
+     */
+    isV1Available() {
+        return this.api && this.api.loggedInStatus === 'Connected';
+    }
+
+    /**
+     * Check if V2 API (API key) is configured and available
+     */
+    isV2Available() {
+        return this.apiV2 && this.apiV2.webclient && this.apiV2.webclient._apiToken;
     }
 
     async debug() {

--- a/drivers/protect-nvr-alarm/device.js
+++ b/drivers/protect-nvr-alarm/device.js
@@ -28,10 +28,10 @@ class NVRAlarmDevice extends Homey.Device {
   }
 
   async waitForBootstrap() {
-    if (
-      typeof this.homey.app.api.getLastUpdateId() !== 'undefined'
-      && this.homey.app.api.getLastUpdateId() !== null
-    ) {
+    const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+    const v2Ready = this.homey.app.isV2Available();
+
+    if (v1Ready || v2Ready) {
       await this.initDevice();
     } else {
       this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);

--- a/drivers/protect-siren/device.js
+++ b/drivers/protect-siren/device.js
@@ -57,7 +57,10 @@ class Siren extends Homey.Device {
     }
 
     async waitForBootstrap() {
-        if (typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null) {
+        const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+        const v2Ready = this.homey.app.isV2Available();
+
+        if (v1Ready || v2Ready) {
             await this.initSiren();
         } else {
             this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);

--- a/drivers/protect-siren/driver.js
+++ b/drivers/protect-siren/driver.js
@@ -18,12 +18,18 @@ class UniFiSirenDriver extends Homey.Driver {
         });
 
         session.setHandler("list_devices", async function (data) {
-            return Object.values(await homey.app.api.getSirens()).map(siren => {
-                return {
-                    data: {id: String(siren.id)},
-                    name: siren.name,
-                };
-            });
+            if (homey.app.isV1Available()) {
+                const sirens = await homey.app.api.getSirens();
+                return Object.values(sirens).map(siren => {
+                    return {
+                        data: {id: String(siren.id)},
+                        name: siren.name,
+                    };
+                });
+            }
+            // Sirens are not supported in the V2 Protect Integration API
+            homey.app.debug('[protect-siren] Sirens not supported in V2 API, requires V1 (username/password)');
+            return [];
         });
     }
 

--- a/drivers/protect-weather/device.js
+++ b/drivers/protect-weather/device.js
@@ -33,10 +33,10 @@ class WeatherDevice extends Homey.Device {
   }
 
   async waitForBootstrap() {
-    if (
-      typeof this.homey.app.api.getLastUpdateId() !== 'undefined'
-      && this.homey.app.api.getLastUpdateId() !== null
-    ) {
+    const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+    const v2Ready = this.homey.app.isV2Available();
+
+    if (v1Ready || v2Ready) {
       await this.initDevice();
     } else {
       this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);

--- a/drivers/protectcamera/device.js
+++ b/drivers/protectcamera/device.js
@@ -55,12 +55,19 @@ class Camera extends Homey.Device {
   async initCamera() {
     this.registerCapabilityListener('camera_microphone_volume', async (value) => {
       this.homey.app.debug('camera_microphone_volume');
-      return this.homey.app.api.setMicVolume(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setMicVolume(this.getData(), value);
+      } else if (this.homey.app.isV2Available()) {
+        return this.homey.app.apiV2.setCamera(this.getData().id, { micVolume: value });
+      }
     });
 
     this.registerCapabilityListener('camera_nightvision_set', async (value) => {
       this.homey.app.debug('camera_nightvision_set');
-      return this.homey.app.api.setNightVisionMode(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setNightVisionMode(this.getData(), value);
+      }
+      // V2 does not expose irLedMode directly
     });
 
     await this._createMissingCapabilities();
@@ -70,7 +77,10 @@ class Camera extends Homey.Device {
   }
 
   async waitForBootstrap() {
-    if (typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null) {
+    const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+    const v2Ready = this.homey.app.isV2Available();
+
+    if (v1Ready || v2Ready) {
       await this.initCamera();
     } else {
       this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);
@@ -171,45 +181,56 @@ class Camera extends Homey.Device {
   }
 
   async _initCameraData() {
-    const cameraData = this.homey.app.api.getBootstrap();
+    let camera = null;
 
-    if (cameraData) {
-      cameraData.cameras.forEach((camera) => {
+    // Try V1 bootstrap first
+    if (this.homey.app.isV1Available()) {
+      const cameraData = this.homey.app.api.getBootstrap();
+      if (cameraData && cameraData.cameras) {
+        camera = cameraData.cameras.find(c => c.id === this.getData().id);
+      }
+    }
 
-        if (camera.id === this.getData().id) {
+    // Fall back to V2 API
+    if (!camera && this.homey.app.isV2Available()) {
+      try {
+        camera = await this.homey.app.apiV2.getCamera(this.getData().id);
+      } catch (e) {
+        this.homey.app.debug(`V2 getCamera failed for ${this.getData().id}: ${e}`);
+      }
+    }
 
-          if (this.hasCapability('ip_address')) {
-            this.setCapabilityValue('ip_address', camera.host).catch(this.error);
-          }
-          if (this.hasCapability('camera_recording_status')) {
-            this.setCapabilityValue('camera_recording_status', camera.isRecording).catch(this.error);
-          }
-          if (this.hasCapability('camera_recording_mode')) {
-            this.setCapabilityValue('camera_recording_mode',
-              this.homey.__(`events.camera.${String(camera.recordingSettings.mode)
-                .toLowerCase()}`)).catch(this.error);
-          }
-          if (this.hasCapability('camera_microphone_status')) {
-            this.setCapabilityValue('camera_microphone_status', camera.isMicEnabled).catch(this.error);
-          }
-          if (this.hasCapability('camera_nightvision_status')) {
-            this.setCapabilityValue('camera_nightvision_status', camera.isDark).catch(this.error);
-          }
-          if (this.hasCapability('camera_microphone_volume')) {
-            this.setCapabilityValue('camera_microphone_volume', camera.micVolume).catch(this.error);
-          }
-          if (this.hasCapability('camera_connection_status')) {
-            if (this.getCapabilityValue('camera_connection_status') !== camera.isConnected) {
-              this.onConnectionChanged(camera.isConnected);
-            }
-            this.setCapabilityValue('camera_connection_status', camera.isConnected).catch(this.error);
-          }
-          if (this.hasCapability('camera_nightvision_set')) {
-            this.setCapabilityValue('camera_nightvision_set', camera.ispSettings.irLedMode).catch(this.error);
-          }
-
+    if (camera) {
+      if (this.hasCapability('ip_address') && camera.host) {
+        this.setCapabilityValue('ip_address', camera.host).catch(this.error);
+      }
+      if (this.hasCapability('camera_recording_status') && typeof camera.isRecording !== 'undefined') {
+        this.setCapabilityValue('camera_recording_status', camera.isRecording).catch(this.error);
+      }
+      if (this.hasCapability('camera_recording_mode') && camera.recordingSettings && camera.recordingSettings.mode) {
+        this.setCapabilityValue('camera_recording_mode',
+          this.homey.__(`events.camera.${String(camera.recordingSettings.mode)
+            .toLowerCase()}`)).catch(this.error);
+      }
+      if (this.hasCapability('camera_microphone_status') && typeof camera.isMicEnabled !== 'undefined') {
+        this.setCapabilityValue('camera_microphone_status', camera.isMicEnabled).catch(this.error);
+      }
+      if (this.hasCapability('camera_nightvision_status') && typeof camera.isDark !== 'undefined') {
+        this.setCapabilityValue('camera_nightvision_status', camera.isDark).catch(this.error);
+      }
+      if (this.hasCapability('camera_microphone_volume') && typeof camera.micVolume !== 'undefined') {
+        this.setCapabilityValue('camera_microphone_volume', camera.micVolume).catch(this.error);
+      }
+      if (this.hasCapability('camera_connection_status')) {
+        const isConnected = camera.state === 'CONNECTED' || camera.isConnected === true;
+        if (this.getCapabilityValue('camera_connection_status') !== isConnected) {
+          this.onConnectionChanged(isConnected);
         }
-      });
+        this.setCapabilityValue('camera_connection_status', isConnected).catch(this.error);
+      }
+      if (this.hasCapability('camera_nightvision_set') && camera.ispSettings && camera.ispSettings.irLedMode) {
+        this.setCapabilityValue('camera_nightvision_set', camera.ispSettings.irLedMode).catch(this.error);
+      }
     }
   }
 
@@ -476,10 +497,22 @@ class Camera extends Homey.Device {
         return;
       }
 
-      await this.homey.app.api.getStreamUrl(this.getData()).then(((rtspUrl) => {
-        this.log(`RTSP URL for camera ${this.getName()}: ${rtspUrl}`);
-        this.rtspUrl = rtspUrl;
-      })).catch(this.error);
+      if (this.homey.app.isV1Available()) {
+        await this.homey.app.api.getStreamUrl(this.getData()).then(((rtspUrl) => {
+          this.log(`RTSP URL for camera ${this.getName()}: ${rtspUrl}`);
+          this.rtspUrl = rtspUrl;
+        })).catch(this.error);
+      } else if (this.homey.app.isV2Available()) {
+        try {
+          const streams = await this.homey.app.apiV2.getRtspsStream(this.getData().id, ['high']);
+          if (streams && streams.high) {
+            this.rtspUrl = streams.high;
+            this.log(`RTSPS URL (V2) for camera ${this.getName()}: ${this.rtspUrl}`);
+          }
+        } catch (e) {
+          this.homey.app.debug(`V2 getRtspsStream failed for ${this.getName()}: ${e}`);
+        }
+      }
 
       this.setCameraVideo('snapshot', `${this.getName()} Video`, this.video);
     } catch (err) {
@@ -494,25 +527,27 @@ class Camera extends Homey.Device {
     const ipAddress = this.getCapabilityValue('ip_address');
 
     this._snapshotImage.setStream(async (stream) => {
-      // Obtain snapshot URL
       let snapshotUrl = null;
+      const headers = {};
 
       if (this.homey.app.useCameraSnapshot) {
         snapshotUrl = `https://${ipAddress}/snap.jpeg`;
-      } else {
+      } else if (this.homey.app.isV1Available()) {
         await this.homey.app.api.createSnapshotUrl(this.getData())
           .then((url) => {
             snapshotUrl = url;
           })
           .catch(this.error.bind(this, 'Could not create snapshot URL.'));
+        headers['Cookie'] = this.homey.app.api.getProxyCookieToken();
+      } else if (this.homey.app.isV2Available()) {
+        snapshotUrl = this.homey.app.apiV2.getSnapshotUrl(this.getData().id);
+        const v2Headers = this.homey.app.apiV2.getSnapshotHeaders();
+        Object.assign(headers, v2Headers);
       }
 
       if (!snapshotUrl) {
         throw new Error('Invalid snapshot url.');
       }
-
-      const headers = {};
-      headers['Cookie'] = this.homey.app.api.getProxyCookieToken();
 
       const agent = new https.Agent({
         rejectUnauthorized: false,
@@ -530,14 +565,21 @@ class Camera extends Homey.Device {
     });
 
     if (triggerFlow) {
-      this.homey.app.api.getStreamUrl(this.getData()).then(((rtspUrl) => {
+      const getStreamUrl = async () => {
+        if (this.homey.app.isV1Available()) {
+          return this.homey.app.api.getStreamUrl(this.getData());
+        }
+        return this.rtspUrl || '';
+      };
+
+      getStreamUrl().then((rtspUrl) => {
         this.homey.app.triggerSnapshotTrigger({
           ufv_snapshot_token: this._snapshotImage,
           ufv_snapshot_camera: this.getName(),
           ufv_snapshot_snapshot_url: '',
           ufv_snapshot_stream_url: rtspUrl,
         });
-      })).catch(this.log);
+      }).catch(this.log);
     }
 
     this.cloudUrl = this._snapshotImage.cloudUrl;

--- a/drivers/protectcamera/driver.js
+++ b/drivers/protectcamera/driver.js
@@ -35,7 +35,15 @@ class UniFiCameraDriver extends Homey.Driver {
 
     session.setHandler('list_devices', async (data) => {
       try {
-        const cameras = await homey.app.api.getCameras();
+        let cameras;
+        if (homey.app.isV1Available()) {
+          cameras = await homey.app.api.getCameras();
+        } else if (homey.app.isV2Available()) {
+          cameras = await homey.app.apiV2.getCamerasNonDoorbell();
+        } else {
+          homey.app.debug('[protectcamera] No API available for listing cameras');
+          return [];
+        }
         return Object.values(cameras).map((camera) => ({
           data: { id: String(camera.id) },
           name: camera.name,

--- a/drivers/protectchime/device.js
+++ b/drivers/protectchime/device.js
@@ -61,7 +61,10 @@ class Chime extends Homey.Device {
   }
 
   async waitForBootstrap() {
-    if (typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null) {
+    const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+    const v2Ready = this.homey.app.isV2Available();
+
+    if (v1Ready || v2Ready) {
       await this.initChime();
     } else {
       this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);

--- a/drivers/protectchime/driver.js
+++ b/drivers/protectchime/driver.js
@@ -23,10 +23,19 @@ class UniFiChimeDriver extends Homey.Driver {
         });
 
         session.setHandler("list_devices", async function (data) {
-            return Object.values(await homey.app.api.getChimes()).map(light => {
+            let chimes;
+            if (homey.app.isV1Available()) {
+                chimes = await homey.app.api.getChimes();
+            } else if (homey.app.isV2Available()) {
+                chimes = await homey.app.apiV2.getChimes();
+            } else {
+                homey.app.debug('[protectchime] No API available for listing chimes');
+                return [];
+            }
+            return Object.values(chimes).map(chime => {
                 return {
-                    data: {id: String(light.id)},
-                    name: light.name,
+                    data: {id: String(chime.id)},
+                    name: chime.name,
                 };
             });
         });

--- a/drivers/protectdoorbell/device.js
+++ b/drivers/protectdoorbell/device.js
@@ -71,22 +71,35 @@ class Doorbell extends Homey.Device {
   async initDoorbell() {
     this.registerCapabilityListener('camera_microphone_volume', async (value) => {
       this.homey.app.debug('camera_microphone_volume');
-      return this.homey.app.api.setMicVolume(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setMicVolume(this.getData(), value);
+      } else if (this.homey.app.isV2Available()) {
+        return this.homey.app.apiV2.setCamera(this.getData().id, { micVolume: value });
+      }
     });
 
     this.registerCapabilityListener('doorbell_ring_volume', async (value) => {
       this.homey.app.debug(`[DoorbellDevice] doorbell_ring_volume: ${value}`);
-      return this.homey.app.api.setDoorbellRingVolume(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setDoorbellRingVolume(this.getData(), value);
+      }
+      // V2 does not expose speakerSettings directly
     });
 
     this.registerCapabilityListener('doorbell_speaker_volume', async (value) => {
       this.homey.app.debug(`[DoorbellDevice] doorbell_speaker_volume: ${value}`);
-      return this.homey.app.api.setDoorbellTalkbackVolume(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setDoorbellTalkbackVolume(this.getData(), value);
+      }
+      // V2 does not expose speakerSettings directly
     });
 
     this.registerCapabilityListener('camera_nightvision_set', async (value) => {
       this.homey.app.debug('camera_nightvision_set');
-      return this.homey.app.api.setNightVisionMode(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setNightVisionMode(this.getData(), value);
+      }
+      // V2 does not expose irLedMode directly
     });
 
     await this._createMissingCapabilities();
@@ -96,7 +109,10 @@ class Doorbell extends Homey.Device {
   }
 
   async waitForBootstrap() {
-    if (typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null) {
+    const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+    const v2Ready = this.homey.app.isV2Available();
+
+    if (v1Ready || v2Ready) {
       await this.initDoorbell();
     } else {
       this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);
@@ -209,54 +225,66 @@ class Doorbell extends Homey.Device {
   }
 
   async _initDoorbellData() {
-    const DoorbellData = this.homey.app.api.getBootstrap();
+    let doorbell = null;
 
-    if (DoorbellData) {
-      for (const Doorbell of DoorbellData.cameras) {
-        if (Doorbell.id === this.getData().id) {
-          if (this.hasCapability('ip_address')) {
-            this.setCapabilityValue('ip_address', Doorbell.host).catch(this.error);
-          }
-          if (this.hasCapability('camera_recording_status')) {
-            this.setCapabilityValue('camera_recording_status', Doorbell.isRecording).catch(this.error);
-          }
-          if (this.hasCapability('camera_recording_mode')) {
-            this.setCapabilityValue('camera_recording_mode',
-              this.homey.__(`events.doorbell.${String(Doorbell.recordingSettings.mode)
-                .toLowerCase()}`)).catch(this.error);
-          }
-          if (this.hasCapability('camera_microphone_status')) {
-            this.setCapabilityValue('camera_microphone_status', Doorbell.isMicEnabled).catch(this.error);
-          }
-          if (this.hasCapability('camera_nightvision_status')) {
-            this.setCapabilityValue('camera_nightvision_status', Doorbell.isDark).catch(this.error);
-          }
-          if (this.hasCapability('camera_microphone_volume')) {
-            this.setCapabilityValue('camera_microphone_volume', Doorbell.micVolume).catch(this.error);
-          }
-          if (this.hasCapability('doorbell_ring_volume') && Doorbell.speakerSettings) {
-            this.setCapabilityValue('doorbell_ring_volume', Doorbell.speakerSettings.ringVolume).catch(this.error);
-          }
-          if (this.hasCapability('doorbell_speaker_volume') && Doorbell.speakerSettings) {
-            this.setCapabilityValue('doorbell_speaker_volume', Doorbell.speakerSettings.speakerVolume).catch(this.error);
-          }
-          if (this.hasCapability('camera_connection_status')) {
-            if (this.getCapabilityValue('camera_connection_status') !== Doorbell.isConnected) {
-              this.onConnectionChanged(Doorbell.isConnected);
-            }
-            this.setCapabilityValue('camera_connection_status', Doorbell.isConnected).catch(this.error);
-          }
-          if (this.hasCapability('camera_nightvision_set')) {
-            this.setCapabilityValue('camera_nightvision_set', Doorbell.ispSettings.irLedMode).catch(this.error);
-          }
+    // Try V1 bootstrap first
+    if (this.homey.app.isV1Available()) {
+      const bootstrapData = this.homey.app.api.getBootstrap();
+      if (bootstrapData && bootstrapData.cameras) {
+        doorbell = bootstrapData.cameras.find(c => c.id === this.getData().id);
+      }
+    }
 
-          // Package camera
-          if (Doorbell.featureFlags.hasPackageCamera) {
-            //
-            await this._createSnapshotPackageImage();
-          }
+    // Fall back to V2 API
+    if (!doorbell && this.homey.app.isV2Available()) {
+      try {
+        doorbell = await this.homey.app.apiV2.getCamera(this.getData().id);
+      } catch (e) {
+        this.homey.app.debug(`V2 getCamera failed for doorbell ${this.getData().id}: ${e}`);
+      }
+    }
 
+    if (doorbell) {
+      if (this.hasCapability('ip_address') && doorbell.host) {
+        this.setCapabilityValue('ip_address', doorbell.host).catch(this.error);
+      }
+      if (this.hasCapability('camera_recording_status') && typeof doorbell.isRecording !== 'undefined') {
+        this.setCapabilityValue('camera_recording_status', doorbell.isRecording).catch(this.error);
+      }
+      if (this.hasCapability('camera_recording_mode') && doorbell.recordingSettings && doorbell.recordingSettings.mode) {
+        this.setCapabilityValue('camera_recording_mode',
+          this.homey.__(`events.doorbell.${String(doorbell.recordingSettings.mode)
+            .toLowerCase()}`)).catch(this.error);
+      }
+      if (this.hasCapability('camera_microphone_status') && typeof doorbell.isMicEnabled !== 'undefined') {
+        this.setCapabilityValue('camera_microphone_status', doorbell.isMicEnabled).catch(this.error);
+      }
+      if (this.hasCapability('camera_nightvision_status') && typeof doorbell.isDark !== 'undefined') {
+        this.setCapabilityValue('camera_nightvision_status', doorbell.isDark).catch(this.error);
+      }
+      if (this.hasCapability('camera_microphone_volume') && typeof doorbell.micVolume !== 'undefined') {
+        this.setCapabilityValue('camera_microphone_volume', doorbell.micVolume).catch(this.error);
+      }
+      if (this.hasCapability('doorbell_ring_volume') && doorbell.speakerSettings) {
+        this.setCapabilityValue('doorbell_ring_volume', doorbell.speakerSettings.ringVolume).catch(this.error);
+      }
+      if (this.hasCapability('doorbell_speaker_volume') && doorbell.speakerSettings) {
+        this.setCapabilityValue('doorbell_speaker_volume', doorbell.speakerSettings.speakerVolume).catch(this.error);
+      }
+      if (this.hasCapability('camera_connection_status')) {
+        const isConnected = doorbell.state === 'CONNECTED' || doorbell.isConnected === true;
+        if (this.getCapabilityValue('camera_connection_status') !== isConnected) {
+          this.onConnectionChanged(isConnected);
         }
+        this.setCapabilityValue('camera_connection_status', isConnected).catch(this.error);
+      }
+      if (this.hasCapability('camera_nightvision_set') && doorbell.ispSettings && doorbell.ispSettings.irLedMode) {
+        this.setCapabilityValue('camera_nightvision_set', doorbell.ispSettings.irLedMode).catch(this.error);
+      }
+
+      // Package camera
+      if (doorbell.featureFlags && doorbell.featureFlags.hasPackageCamera) {
+        await this._createSnapshotPackageImage();
       }
     }
   }
@@ -635,10 +663,22 @@ class Doorbell extends Homey.Device {
       }
 
       // get rtsp url from api
-      this.homey.app.api.getStreamUrl(this.getData()).then(((rtspUrl) => {
-        this.log(`RTSP URL for doorbell ${this.getName()}: ${rtspUrl}`);
-        this.rtspUrl = rtspUrl;
-      })).catch(this.error);
+      if (this.homey.app.isV1Available()) {
+        this.homey.app.api.getStreamUrl(this.getData()).then(((rtspUrl) => {
+          this.log(`RTSP URL for doorbell ${this.getName()}: ${rtspUrl}`);
+          this.rtspUrl = rtspUrl;
+        })).catch(this.error);
+      } else if (this.homey.app.isV2Available()) {
+        try {
+          const streams = await this.homey.app.apiV2.getRtspsStream(this.getData().id, ['high']);
+          if (streams && streams.high) {
+            this.rtspUrl = streams.high;
+            this.log(`RTSPS URL (V2) for doorbell ${this.getName()}: ${this.rtspUrl}`);
+          }
+        } catch (e) {
+          this.homey.app.debug(`V2 getRtspsStream failed for ${this.getName()}: ${e}`);
+        }
+      }
 
       this.setCameraVideo('snapshot', `${this.getName()} Video`, this.video);
 
@@ -664,10 +704,22 @@ class Doorbell extends Homey.Device {
       }
 
       // get rtsp url from api
-      this.homey.app.api.getPackageStreamUrl(this.getData()).then(((rtspPackageUrl) => {
-        this.log(`RTSP URL for doorbell ${this.getName()}: ${rtspPackageUrl}`);
-        this.rtspPackageUrl = rtspPackageUrl;
-      })).catch(this.error);
+      if (this.homey.app.isV1Available()) {
+        this.homey.app.api.getPackageStreamUrl(this.getData()).then(((rtspPackageUrl) => {
+          this.log(`RTSP URL for doorbell ${this.getName()}: ${rtspPackageUrl}`);
+          this.rtspPackageUrl = rtspPackageUrl;
+        })).catch(this.error);
+      } else if (this.homey.app.isV2Available()) {
+        try {
+          const streams = await this.homey.app.apiV2.getRtspsStream(this.getData().id, ['package']);
+          if (streams && streams.package) {
+            this.rtspPackageUrl = streams.package;
+            this.log(`RTSPS Package URL (V2) for doorbell ${this.getName()}: ${this.rtspPackageUrl}`);
+          }
+        } catch (e) {
+          this.homey.app.debug(`V2 getRtspsStream (package) failed for ${this.getName()}: ${e}`);
+        }
+      }
 
       this.setCameraVideo('package-snapshot', `${this.getName()} Package Video`, this.packageVideo);
     } catch (err) {
@@ -683,25 +735,27 @@ class Doorbell extends Homey.Device {
     const ipAddress = this.getCapabilityValue('ip_address');
 
     this._snapshotImage.setStream(async (stream) => {
-      // Obtain snapshot URL
       let snapshotUrl = null;
+      const headers = {};
 
       if (this.homey.app.useCameraSnapshot) {
         snapshotUrl = `https://${ipAddress}/snap.jpeg`;
-      } else {
+      } else if (this.homey.app.isV1Available()) {
         await this.homey.app.api.createSnapshotUrl(this.getData())
           .then((url) => {
             snapshotUrl = url;
           })
           .catch(this.error.bind(this, 'Could not create snapshot URL.'));
+        headers['Cookie'] = this.homey.app.api.getProxyCookieToken();
+      } else if (this.homey.app.isV2Available()) {
+        snapshotUrl = this.homey.app.apiV2.getSnapshotUrl(this.getData().id);
+        const v2Headers = this.homey.app.apiV2.getSnapshotHeaders();
+        Object.assign(headers, v2Headers);
       }
 
       if (!snapshotUrl) {
         throw new Error('Invalid snapshot url.');
       }
-
-      const headers = {};
-      headers['Cookie'] = this.homey.app.api.getProxyCookieToken();
 
       const agent = new https.Agent({
         rejectUnauthorized: false,
@@ -719,14 +773,21 @@ class Doorbell extends Homey.Device {
     });
 
     if (triggerFlow) {
-      this.homey.app.api.getStreamUrl(this.getData()).then(((rtspUrl) => {
+      const getStreamUrl = async () => {
+        if (this.homey.app.isV1Available()) {
+          return this.homey.app.api.getStreamUrl(this.getData());
+        }
+        return this.rtspUrl || '';
+      };
+
+      getStreamUrl().then((rtspUrl) => {
         this.homey.app.triggerSnapshotTrigger({
           ufv_snapshot_token: this._snapshotImage,
           ufv_snapshot_camera: this.getName(),
           ufv_snapshot_snapshot_url: '',
           ufv_snapshot_stream_url: rtspUrl,
         });
-      })).catch(this.log);
+      }).catch(this.log);
     }
 
     this.setCameraImage('snapshot', this.getName(), this._snapshotImage).catch(this.error);
@@ -744,24 +805,28 @@ class Doorbell extends Homey.Device {
       const ipAddress = this.getCapabilityValue('ip_address');
 
       this._snapshotPackageImage.setStream(async (stream) => {
-        // Obtain snapshot URL
         let snapshotUrl = null;
+        const headers = {};
 
         if (this.homey.app.useCameraSnapshot) {
           snapshotUrl = `https://${ipAddress}/snap_2.jpeg`;
-        } else {
+        } else if (this.homey.app.isV1Available()) {
           await this.homey.app.api.createPackageSnapshotUrl(this.getData())
             .then((url) => {
               snapshotUrl = url;
             });
-        }
-        reject('Invalid snapshot url.');
-        if (!snapshotUrl) {
-          reject('Invalid snapshot url.');
+          headers['Cookie'] = this.homey.app.api.getProxyCookieToken();
+        } else if (this.homey.app.isV2Available()) {
+          // V2 snapshot endpoint (package camera not separately supported in V2)
+          snapshotUrl = this.homey.app.apiV2.getSnapshotUrl(this.getData().id);
+          const v2Headers = this.homey.app.apiV2.getSnapshotHeaders();
+          Object.assign(headers, v2Headers);
         }
 
-        const headers = {};
-        headers['Cookie'] = this.homey.app.api.getProxyCookieToken();
+        if (!snapshotUrl) {
+          reject('Invalid snapshot url.');
+          return;
+        }
 
         const agent = new https.Agent({
           rejectUnauthorized: false,
@@ -775,20 +840,28 @@ class Doorbell extends Homey.Device {
         });
         if (!res.ok) {
           reject('Could not fetch snapshot image.');
+          return;
         }
 
         return res.body.pipe(stream);
       });
 
       if (triggerFlow) {
-        this.homey.app.api.getPackageStreamUrl(this.getData()).then(((rtspUrl) => {
+        const getStreamUrl = async () => {
+          if (this.homey.app.isV1Available()) {
+            return this.homey.app.api.getPackageStreamUrl(this.getData());
+          }
+          return this.rtspPackageUrl || '';
+        };
+
+        getStreamUrl().then((rtspUrl) => {
           this.homey.app._packageSnapshotTrigger.trigger({
             ufv_snapshot_token: this._snapshotPackageImage,
             ufv_snapshot_camera: this.getName(),
             ufv_snapshot_snapshot_url: '',
             ufv_snapshot_stream_url: rtspUrl,
           });
-        }));
+        }).catch(this.error);
       }
 
       this.setCameraImage('package-snapshot', this.homey.__('package_camera', { name: this.getName() }), this._snapshotPackageImage).catch(this.error);

--- a/drivers/protectdoorbell/driver.js
+++ b/drivers/protectdoorbell/driver.js
@@ -39,7 +39,15 @@ class UniFiDoorbellDriver extends Homey.Driver {
 
         session.setHandler("list_devices", async function (data) {
             try {
-                const doorbells = await homey.app.api.getDoorbells();
+                let doorbells;
+                if (homey.app.isV1Available()) {
+                    doorbells = await homey.app.api.getDoorbells();
+                } else if (homey.app.isV2Available()) {
+                    doorbells = await homey.app.apiV2.getDoorbells();
+                } else {
+                    homey.app.debug('[protectdoorbell] No API available for listing doorbells');
+                    return [];
+                }
                 return Object.values(doorbells).map((camera) => ({
                     data: { id: String(camera.id) },
                     name: camera.name,

--- a/drivers/protectlight/device.js
+++ b/drivers/protectlight/device.js
@@ -49,15 +49,37 @@ class Light extends Homey.Device {
 
   async initLight() {
     this.registerCapabilityListener("onoff", (value) => {
-      return this.homey.app.api.setLightOn(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setLightOn(this.getData(), value);
+      } else if (this.homey.app.isV2Available()) {
+        return this.homey.app.apiV2.setLight(this.getData().id, { isLightForceEnabled: value });
+      }
     });
 
     this.registerCapabilityListener("dim", (value) => {
-      return this.homey.app.api.setLightLevel(this.getData(), this.translateLedLevel(value, true));
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setLightLevel(this.getData(), this.translateLedLevel(value, true));
+      } else if (this.homey.app.isV2Available()) {
+        return this.homey.app.apiV2.setLight(this.getData().id, {
+          lightDeviceSettings: { ledLevel: this.translateLedLevel(value, true) }
+        });
+      }
     });
 
     this.registerCapabilityListener("light_mode_unifi", (value) => {
-      return this.homey.app.api.setLightMode(this.getData(), value);
+      if (this.homey.app.isV1Available()) {
+        return this.homey.app.api.setLightMode(this.getData(), value);
+      } else if (this.homey.app.isV2Available()) {
+        let lightModeSettings = {};
+        if (value === "motion") {
+          lightModeSettings = { mode: "motion", enableAt: "fulltime" };
+        } else if (value === "dark") {
+          lightModeSettings = { mode: "motion", enableAt: "dark" };
+        } else {
+          lightModeSettings = { mode: value, enableAt: "dark" };
+        }
+        return this.homey.app.apiV2.setLight(this.getData().id, { lightModeSettings });
+      }
     });
 
     await this._createMissingCapabilities();
@@ -65,7 +87,10 @@ class Light extends Homey.Device {
   }
 
   async waitForBootstrap() {
-    if (typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null) {
+    const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+    const v2Ready = this.homey.app.isV2Available();
+
+    if (v1Ready || v2Ready) {
       await this.initLight();
     } else {
       this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);
@@ -85,21 +110,35 @@ class Light extends Homey.Device {
   }
 
   async _initLightData() {
-    const bootstrapData = this.homey.app.api.getBootstrap();
-    if (bootstrapData) {
-      bootstrapData.lights.forEach((light) => {
-        if (light.id === this.getData().id) {
-          if (this.hasCapability('onoff')) {
-            this.setCapabilityValue('onoff', light.isLightOn);
-          }
-          if (this.hasCapability('dim')) {
-            this.setCapabilityValue('dim', this.translateLedLevel(light.lightDeviceSettings.ledLevel, false));
-          }
-          if (this.hasCapability('light_mode_unifi')) {
-            this.setCapabilityValue('light_mode_unifi', this.translateLightMode(light.lightModeSettings));
-          }
-        }
-      });
+    let light = null;
+
+    // Try V1 bootstrap first
+    if (this.homey.app.isV1Available()) {
+      const bootstrapData = this.homey.app.api.getBootstrap();
+      if (bootstrapData && bootstrapData.lights) {
+        light = bootstrapData.lights.find(l => l.id === this.getData().id);
+      }
+    }
+
+    // Fall back to V2 API
+    if (!light && this.homey.app.isV2Available()) {
+      try {
+        light = await this.homey.app.apiV2.getLight(this.getData().id);
+      } catch (e) {
+        this.homey.app.debug(`V2 getLight failed for ${this.getData().id}: ${e}`);
+      }
+    }
+
+    if (light) {
+      if (this.hasCapability('onoff')) {
+        this.setCapabilityValue('onoff', light.isLightOn);
+      }
+      if (this.hasCapability('dim') && light.lightDeviceSettings) {
+        this.setCapabilityValue('dim', this.translateLedLevel(light.lightDeviceSettings.ledLevel, false));
+      }
+      if (this.hasCapability('light_mode_unifi') && light.lightModeSettings) {
+        this.setCapabilityValue('light_mode_unifi', this.translateLightMode(light.lightModeSettings));
+      }
     }
   }
 

--- a/drivers/protectlight/driver.js
+++ b/drivers/protectlight/driver.js
@@ -18,7 +18,16 @@ class UniFiLightDriver extends Homey.Driver {
         });
 
         session.setHandler("list_devices", async function (data) {
-            return Object.values(await homey.app.api.getLights()).map(light => {
+            let lights;
+            if (homey.app.isV1Available()) {
+                lights = await homey.app.api.getLights();
+            } else if (homey.app.isV2Available()) {
+                lights = await homey.app.apiV2.getLights();
+            } else {
+                homey.app.debug('[protectlight] No API available for listing lights');
+                return [];
+            }
+            return Object.values(lights).map(light => {
                 return {
                     data: {id: String(light.id)},
                     name: light.name,

--- a/drivers/protectsensor/device.js
+++ b/drivers/protectsensor/device.js
@@ -68,7 +68,10 @@ class Sensor extends Homey.Device {
     }
 
     async waitForBootstrap() {
-        if (typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null) {
+        const v1Ready = typeof this.homey.app.api.getLastUpdateId() !== 'undefined' && this.homey.app.api.getLastUpdateId() !== null;
+        const v2Ready = this.homey.app.isV2Available();
+
+        if (v1Ready || v2Ready) {
             await this.initSensor();
         } else {
             this.homey.setTimeout(this.waitForBootstrap.bind(this), 250);

--- a/drivers/protectsensor/driver.js
+++ b/drivers/protectsensor/driver.js
@@ -18,7 +18,16 @@ class UniFiSensorDriver extends Homey.Driver {
         });
 
         session.setHandler("list_devices", async function (data) {
-            return Object.values(await homey.app.api.getSensors()).map(sensor => {
+            let sensors;
+            if (homey.app.isV1Available()) {
+                sensors = await homey.app.api.getSensors();
+            } else if (homey.app.isV2Available()) {
+                sensors = await homey.app.apiV2.getSensors();
+            } else {
+                homey.app.debug('[protectsensor] No API available for listing sensors');
+                return [];
+            }
+            return Object.values(sensors).map(sensor => {
                 return {
                     data: {id: String(sensor.id)},
                     name: sensor.name,

--- a/library/SmartDetectionMixin.js
+++ b/library/SmartDetectionMixin.js
@@ -87,7 +87,7 @@ const SmartDetectionMixin = {
     }
 
     const lastDetectionAt = event.detectionTime;
-    const score = event.detectionScore;
+    const score = typeof event.detectionScore === 'number' ? event.detectionScore : 0;
     const smartDetectTypes = event.detectionTypes;
 
     let zones = '';
@@ -103,7 +103,9 @@ const SmartDetectionMixin = {
     this.setCapabilityValue('last_smart_detection_at', lastDetectionAt).catch(this.error);
     this.setCapabilityValue('last_smart_detection_date', lastDetection.toLocaleDateString()).catch(this.error);
     this.setCapabilityValue('last_smart_detection_time', lastDetection.toLocaleTimeString()).catch(this.error);
-    this.setCapabilityValue('last_smart_detection_score', score).catch(this.error);
+    if (typeof score === 'number') {
+      this.setCapabilityValue('last_smart_detection_score', score).catch(this.error);
+    }
 
     if (smartDetectTypes.length > 0) {
       for (const type of smartDetectTypes) {

--- a/library/app-protect.js
+++ b/library/app-protect.js
@@ -70,7 +70,12 @@ class AppProtect extends BaseClass {
         const _setRecordingModeV2 = this.homey.flow.getActionCard(UfvConstants.ACTION_SET_RECORDING_MODE_V2);
         _setRecordingModeV2.registerRunListener(async (args, state) => {
             if (typeof args.device.getData().id !== 'undefined') {
-                return this.homey.app.api.setRecordingMode(args.device.getData(), args.recording_mode);
+                if (this.homey.app.isV1Available()) {
+                    return this.homey.app.api.setRecordingMode(args.device.getData(), args.recording_mode);
+                } else if (this.homey.app.isV2Available()) {
+                    // V2 does not support changing recording mode directly
+                    this.homey.app.debug('[V2] setRecordingMode not available in V2 Integration API');
+                }
             }
             return Promise.resolve(true);
         });
@@ -483,8 +488,13 @@ class AppProtect extends BaseClass {
         const refreshAuthTokens = this.homey.setInterval(() => {
             try {
                 this.homey.app.debug('Refreshing auth tokens');
-                this.homey.app.api._lastUpdateId = null;
-                this._appLogin();
+
+                // Only refresh V1 (username/password) if credentials are configured
+                const credentials = this.homey.settings.get('ufp:credentials');
+                if (credentials && credentials.username && credentials.password) {
+                    this.homey.app.api._lastUpdateId = null;
+                    this._appLogin();
+                }
 
                 // clean Device Storage
                 this.cleanDeviceStorage();
@@ -500,8 +510,14 @@ class AppProtect extends BaseClass {
                     && tokens.protectV2ApiKey !== ''
                     && !this.homey.app.apiV2.websocket.isWebsocketConnected()
                 ) {
-                    this.homey.appProtect.loginToProtectV2().catch(this.error);
-                    this.homey.appAccess.loginToAccess().catch(this.error);
+                    this.homey.app.appProtect.loginToProtectV2().catch(this.error);
+                }
+
+                if (
+                    tokens && typeof tokens.accessApiKey !== 'undefined'
+                    && tokens.accessApiKey !== ''
+                ) {
+                    this.homey.app.appAccess.loginToAccess().catch(this.error);
                 }
             } catch (error) {
                 this.homey.error(`${JSON.stringify(error)}`);

--- a/library/protect-api-v2/protect-api.js
+++ b/library/protect-api-v2/protect-api.js
@@ -56,6 +56,36 @@ class ProtectAPI extends BaseClass {
                 .catch(error => reject(error));
         });
     }
+    async getDoorbells() {
+        return new Promise((resolve, reject) => {
+            this.webclient.get('cameras')
+                .then(response => {
+                    let result = JSON.parse(response);
+                    result = result.filter(obj => obj.featureFlags && obj.featureFlags.isDoorbell === true);
+                    if (result) {
+                        return resolve(result);
+                    } else {
+                        return reject(new Error('Error obtaining doorbells.'));
+                    }
+                })
+                .catch(error => reject(error));
+        });
+    }
+    async getCamerasNonDoorbell() {
+        return new Promise((resolve, reject) => {
+            this.webclient.get('cameras')
+                .then(response => {
+                    let result = JSON.parse(response);
+                    result = result.filter(obj => !obj.featureFlags || obj.featureFlags.isDoorbell !== true);
+                    if (result) {
+                        return resolve(result);
+                    } else {
+                        return reject(new Error('Error obtaining cameras.'));
+                    }
+                })
+                .catch(error => reject(error));
+        });
+    }
     async setCamera(cameraId, params) {
         return new Promise((resolve, reject) => {
             this.webclient.patch('cameras/' + cameraId, params)
@@ -206,6 +236,59 @@ class ProtectAPI extends BaseClass {
                         return resolve(result);
                     } else {
                         return reject(new Error('Error setting chime.'));
+                    }
+                })
+                .catch(error => reject(error));
+        });
+    }
+
+    // Snapshot
+    getSnapshotUrl(cameraId, highQuality = false) {
+        const host = this.webclient._serverHost;
+        const port = this.webclient._serverPort;
+        const quality = highQuality ? 'true' : 'false';
+        return `https://${host}:${port}/proxy/protect/integration/v1/cameras/${cameraId}/snapshot?highQuality=${quality}`;
+    }
+
+    getSnapshotHeaders() {
+        return {
+            'X-API-KEY': this.webclient._apiToken,
+        };
+    }
+
+    async getSnapshot(cameraId) {
+        return new Promise((resolve, reject) => {
+            this.webclient.get(`cameras/${cameraId}/snapshot`)
+                .then(buffer => resolve(buffer))
+                .catch(error => reject(error));
+        });
+    }
+
+    // RTSPS Streams
+    async getRtspsStream(cameraId, qualities = ['high']) {
+        return new Promise((resolve, reject) => {
+            this.webclient.post(`cameras/${cameraId}/rtsps-stream`, { qualities })
+                .then(response => {
+                    let result = JSON.parse(response);
+                    if (result) {
+                        return resolve(result);
+                    } else {
+                        return reject(new Error('Error creating RTSPS stream.'));
+                    }
+                })
+                .catch(error => reject(error));
+        });
+    }
+
+    async getExistingRtspsStream(cameraId) {
+        return new Promise((resolve, reject) => {
+            this.webclient.get(`cameras/${cameraId}/rtsps-stream`)
+                .then(response => {
+                    let result = JSON.parse(response);
+                    if (result) {
+                        return resolve(result);
+                    } else {
+                        return reject(new Error('Error obtaining RTSPS stream.'));
                     }
                 })
                 .catch(error => reject(error));

--- a/library/protect-api-v2/web-client.js
+++ b/library/protect-api-v2/web-client.js
@@ -48,6 +48,49 @@ class WebClient extends BaseClass {
             req.end();
         });
     }
+    async post(resource, payload = {}) {
+        return new Promise((resolve, reject) => {
+            const body = JSON.stringify(payload);
+
+            const options = {
+                method: 'POST',
+                hostname: this._serverHost,
+                port: this._serverPort,
+                path: `/proxy/protect/integration/v1/${resource}`,
+                headers: {
+                    'Content-Type': 'application/json; charset=utf-8',
+                    'Content-Length': Buffer.byteLength(body),
+                    Accept: '*/*',
+                    'X-API-KEY': `${this._apiToken}`,
+                },
+                maxRedirects: 20,
+                rejectUnauthorized: false,
+                keepAlive: true,
+            };
+
+            const req = https.request(options, res => {
+                res.setEncoding('utf8');
+                const data = [];
+
+                res.on('data', chunk => data.push(chunk));
+                res.on('end', () => {
+                    if (res.statusCode === 403) {
+                        return reject(new Error(`Homey user has no permission to perform this action. Please check the user's role.`));
+                    }
+
+                    if (res.statusCode !== 200 && res.statusCode !== 201 && res.statusCode !== 204) {
+                        return reject(new Error(`Failed to POST to url: ${options.path} (status code: ${res.statusCode}, response: ${data.join('')})`));
+                    }
+
+                    return resolve(data.join(''));
+                });
+            });
+
+            req.on('error', error => reject(error));
+            req.write(body);
+            req.end();
+        });
+    }
     async put(resource, payload = {}) {
         return new Promise((resolve, reject) => {
             const body = JSON.stringify(payload);

--- a/library/protect-api-v2/web-socket-devices.js
+++ b/library/protect-api-v2/web-socket-devices.js
@@ -147,7 +147,63 @@ class ProtectWebSocket extends BaseClass {
 
       this.lastWebsocketMessage = this.homey.app.toLocalTime(new Date()).toISOString().slice(0, 16);
 
-      this.homey.app.log('Websocket Devices event received: ' + JSON.stringify(eventData));
+      this.homey.app.debug('Websocket V2 Devices event received: ' + JSON.stringify(eventData));
+
+      if (!eventData || !eventData.item || !eventData.item.modelKey) {
+        return;
+      }
+
+      const payload = eventData.item;
+      const modelKey = payload.modelKey;
+      const deviceId = payload.id;
+
+      this.homey.app.debug('[V2 Devices WS] ' + modelKey + ' ' + deviceId + ' ' + eventData.type);
+
+      try {
+        if (modelKey === 'camera') {
+          const driverCamera = this.homey.drivers.getDriver('protectcamera');
+          const deviceCamera = driverCamera.getUnifiDeviceById(deviceId);
+          if (deviceCamera) {
+            driverCamera.onParseWebsocketMessage(deviceCamera, payload);
+          }
+
+          const driverDoorbell = this.homey.drivers.getDriver('protectdoorbell');
+          const deviceDoorbell = driverDoorbell.getUnifiDeviceById(deviceId);
+          if (deviceDoorbell) {
+            driverDoorbell.onParseWebsocketMessage(deviceDoorbell, payload);
+          }
+        } else if (modelKey === 'light') {
+          const driver = this.homey.drivers.getDriver('protectlight');
+          const device = driver.getUnifiDeviceById(deviceId);
+          if (device) {
+            driver.onParseWebsocketMessage(device, payload);
+          }
+        } else if (modelKey === 'sensor') {
+          const driver = this.homey.drivers.getDriver('protectsensor');
+          const device = driver.getUnifiDeviceById(deviceId);
+          if (device) {
+            driver.onParseWebsocketMessage(device, payload);
+          }
+        } else if (modelKey === 'chime') {
+          const driver = this.homey.drivers.getDriver('protectchime');
+          const device = driver.getUnifiDeviceById(deviceId);
+          if (device) {
+            driver.onParseWebsocketMessage(device, payload);
+          }
+        } else if (modelKey === 'nvr') {
+          try {
+            const alarmDriver = this.homey.drivers.getDriver('protect-nvr-alarm');
+            const alarmDevice = alarmDriver.getNVRAlarmDevice();
+            if (alarmDevice) {
+              alarmDriver.onParseWebsocketMessage(alarmDevice, payload);
+            }
+          } catch (e) {
+            // driver may not be installed
+          }
+        }
+      } catch (e) {
+        this.homey.app.debug('[V2 Devices WS] dispatch error: ' + e);
+      }
 
     });
     this._eventListenerConfigured = true;

--- a/library/protect-api-v2/web-socket-events.js
+++ b/library/protect-api-v2/web-socket-events.js
@@ -147,46 +147,74 @@ class ProtectWebSocket extends BaseClass {
 
             this.lastWebsocketMessage = this.homey.app.toLocalTime(new Date()).toISOString().slice(0, 16);
 
-            // this.homey.app.log('Websocket Events event received: ' + JSON.stringify(eventData));
+            this.homey.app.debug('[V2 Events WS] ' + JSON.stringify(eventData));
 
-            // {"item":{"id":"68d7a86500bddd03e4534022","modelKey":"event","type":"ring","start":1758963811189,"device":"672e0e8103aadb03e40003ff"},"type":"add"}
+            if (!eventData || !eventData.item || !eventData.item.device) {
+                return;
+            }
 
-            // {"item":{"id":"68d7a86400b0dd03e4533fd8","modelKey":"event","type":"smartDetectZone","start":1758963809984,"device":"672e0e8103aadb03e40003ff","smartDetectTypes":[]},"type":"add"}
-            // {"item":{"id":"68d7a86400b0dd03e4533fd8","modelKey":"event","type":"smartDetectZone","start":1758963809984,"device":"672e0e8103aadb03e40003ff","smartDetectTypes":["person"]},"type":"update"}
+            const item = eventData.item;
+            const deviceId = item.device;
+            const eventType = eventData.type; // 'add' or 'update'
+            const itemType = item.type; // 'ring', 'motion', 'smartDetectZone', etc.
 
-            // {"item":{"id":"68d7a86303addd03e4533fcd","modelKey":"event","type":"motion","start":1758963808651,"device":"672e0e8103aadb03e40003ff"},"type":"add"}
-            // {"item":{"id":"68d7a86303addd03e4533fcd","modelKey":"event","type":"motion","start":1758963808651,"device":"672e0e8103aadb03e40003ff"},"type":"update"}
-
-            if (
-                eventData.type === 'add'
-                && typeof eventData.item.device !== 'undefined'
-                && eventData.item.type === 'ring'
-            ) {
-                this.homey.app.log('doorbell ring event received');
-
-                const driverDoorbell = this.homey.drivers.getDriver('protectdoorbell');
-                const deviceDoorbell = driverDoorbell.getUnifiDeviceById(eventData.item.device);
-                if (deviceDoorbell) {
-                    deviceDoorbell.onDoorbellRinging(eventData.item.start)
-                }
-            } else if (
-                eventData.type === 'add'
-                && typeof eventData.item.device !== 'undefined'
-                && eventData.item.type === 'motion'
-            ) {
-                this.homey.app.log('camera motion event received');
+            try {
                 const driverCamera = this.homey.drivers.getDriver('protectcamera');
                 const driverDoorbell = this.homey.drivers.getDriver('protectdoorbell');
-                const deviceCamera = driverCamera.getUnifiDeviceById(eventData.item.device);
-                const deviceDoorbell = driverDoorbell.getUnifiDeviceById(eventData.item.device);
-                if (deviceCamera) {
-                    deviceCamera.onMotionDetected(eventData.item.start, true);
+                const deviceCamera = driverCamera.getUnifiDeviceById(deviceId);
+                const deviceDoorbell = driverDoorbell.getUnifiDeviceById(deviceId);
+
+                // Ring event (doorbell)
+                if (itemType === 'ring' && eventType === 'add') {
+                    this.homey.app.debug('[V2] doorbell ring event');
+                    if (deviceDoorbell) {
+                        deviceDoorbell.onDoorbellRinging(item.start);
+                    }
                 }
-                if (deviceDoorbell) {
-                    deviceDoorbell.onMotionDetected(eventData.item.start, true);
+
+                // Motion event
+                if (itemType === 'motion') {
+                    if (eventType === 'add') {
+                        // Motion started
+                        this.homey.app.debug('[V2] motion start on ' + deviceId);
+                        if (deviceCamera) {
+                            deviceCamera.onMotionDetected(item.start, true);
+                        }
+                        if (deviceDoorbell) {
+                            deviceDoorbell.onMotionDetected(item.start, true);
+                        }
+                    } else if (eventType === 'update' && item.end) {
+                        // Motion ended
+                        this.homey.app.debug('[V2] motion end on ' + deviceId);
+                        if (deviceCamera) {
+                            deviceCamera.onMotionDetected(item.end, false);
+                        }
+                        if (deviceDoorbell) {
+                            deviceDoorbell.onMotionDetected(item.end, false);
+                        }
+                    }
                 }
-            } else {
-                this.homey.app.log('Websocket unhandled event received: ' + JSON.stringify(eventData));
+
+                // Smart detection event
+                if (itemType === 'smartDetectZone') {
+                    if (item.smartDetectTypes && item.smartDetectTypes.length > 0) {
+                        this.homey.app.debug('[V2] smart detection: ' + JSON.stringify(item.smartDetectTypes) + ' on ' + deviceId);
+                        const payload = {
+                            smartDetectTypes: item.smartDetectTypes,
+                            start: item.start,
+                            end: item.end || null,
+                        };
+                        if (deviceCamera) {
+                            driverCamera.onParseWebsocketMessage(deviceCamera, payload, eventType, item.id);
+                        }
+                        if (deviceDoorbell) {
+                            driverDoorbell.onParseWebsocketMessage(deviceDoorbell, payload, eventType, item.id);
+                        }
+                    }
+                }
+
+            } catch (e) {
+                this.homey.app.debug('[V2 Events WS] dispatch error: ' + e);
             }
         });
         this._eventListenerConfigured = true;

--- a/settings/index.html
+++ b/settings/index.html
@@ -19,7 +19,6 @@
 <div id="protect" class="tabcontent">
     <!-- Instruction -->
     <p data-i18n="settings.instruction"></p>
-    <p>Please read first the instructions and create a separate user for UniFi Network</p>
 
     <!-- NVR -->
     <fieldset class="homey-form-fieldset">
@@ -54,6 +53,11 @@
             <label class="homey-form-label" for="txt_password" data-i18n="settings.password"></label>
             <input class="homey-form-input" id="txt_password" type="password" value=""/>
         </div>
+    </fieldset>
+
+    <!-- V2 API Key (new) -->
+    <fieldset class="homey-form-fieldset">
+        <legend class="homey-form-legend">Protect V2 API Key (New)</legend>
 
         <!-- API-Key -->
         <div class="field row">
@@ -61,7 +65,7 @@
             <input class="homey-form-input" id="txt_protectV2ApiKey" type="text" value=""/>
         </div>
         <p>
-            <em>Only required if you want to test the new V2 connection.</em>
+            <em>Optional: connect using a V2 API key. Can be used standalone or together with V1 credentials.</em>
         </p>
     </fieldset>
 
@@ -134,30 +138,44 @@
     <!-- Title -->
     <legend class="homey-form-legend" data-i18n="settings.status"></legend>
 
-    <p><span data-i18n="settings.status">Status</span>: <span id="unifi_status"
-                                                              style="font-weight: bold;">Unknown</span>
-    </p>
-    <p><span data-i18n="settings.websocket.status">Protect V1 Realtime Status</span>: <span id="unifi_websocket_status"
-                                                                                            style="font-weight: bold;">Unknown</span>
-    </p>
-    <p><span data-i18n="settings.websocket.at">Protect V1 Last update at</span>: <span id="unifi_websocket_at"
-                                                                                       style="font-weight: bold;">Unknown</span>
-    </p>
-    <p><span data-i18n="settings.protectV2Websocket.status">Protect V2 Realtime Status</span>: <span
-            id="unifi_protectV2_websocket_status"
-            style="font-weight: bold;">Unknown</span>
-    </p>
-    <p><span data-i18n="settings.protectV2Websocket.at">Protect V2 Last update at</span>: <span
-            id="unifi_protectV2_websocket_at"
-            style="font-weight: bold;">Unknown</span>
-    </p>
-    <p><span data-i18n="settings.accessWebsocket.status">Access Realtime Status</span>: <span
+    <!-- Protect V1 -->
+    <fieldset class="homey-form-fieldset">
+        <legend class="homey-form-legend">Protect V1 (Username/Password)</legend>
+        <p><span>Status</span>: <span id="unifi_status"
+                                      style="font-weight: bold;">Unknown</span>
+        </p>
+        <p><span>Realtime Status</span>: <span id="unifi_websocket_status"
+                                               style="font-weight: bold;">Unknown</span>
+        </p>
+        <p><span>Last update at</span>: <span id="unifi_websocket_at"
+                                              style="font-weight: bold;">Unknown</span>
+        </p>
+    </fieldset>
+
+    <!-- Protect V2 -->
+    <fieldset class="homey-form-fieldset">
+        <legend class="homey-form-legend">Protect V2 API Key (New)</legend>
+        <p><span>Realtime Status</span>: <span
+                id="unifi_protectV2_websocket_status"
+                style="font-weight: bold;">Unknown</span>
+        </p>
+        <p><span>Last update at</span>: <span
+                id="unifi_protectV2_websocket_at"
+                style="font-weight: bold;">Unknown</span>
+        </p>
+    </fieldset>
+
+    <!-- Access -->
+    <fieldset class="homey-form-fieldset">
+        <legend class="homey-form-legend">Access</legend>
+        <p><span data-i18n="settings.accessWebsocket.status">Access Realtime Status</span>: <span
             id="unifi_access_websocket_status"
             style="font-weight: bold;">Unknown</span>
     </p>
     <p><span data-i18n="settings.accessWebsocket.at">Access Last update at</span>: <span id="unifi_access_websocket_at"
                                                                                          style="font-weight: bold;">Unknown</span>
     </p>
+    </fieldset>
 </div>
 
 <script type="text/javascript">
@@ -292,7 +310,8 @@
                 if (err) return Homey.alert(err);
                 if (response) {
                     if (response.status === 'success') {
-                        Homey.alert(Homey.__('settings.test_status.success'), 'info');
+                        var msg = response.message || Homey.__('settings.test_status.success');
+                        Homey.alert(msg, 'info');
                     } else {
                         Homey.alert(Homey.__('settings.test_status.failure'), 'error');
                     }


### PR DESCRIPTION
## Summary
- V1 (username/password) and V2 (API key) now work **independently** — you can use the app with only a V2 API key, no full user required
- V1 remains the main/default, V2 is marked as "New" in the UI
- All protect drivers, devices, snapshots, streams and websockets support V2-only mode
- Bug fix: `refreshAuthTokens()` referenced `this.homey.appProtect` instead of `this.homey.app.appProtect`
- Bug fix: `SmartDetectionMixin` crashed on V2 events where `score` is undefined

## What changed
- **Startup**: V1 login only attempted when credentials exist
- **Drivers**: All protect drivers fall back to V2 API for device pairing
- **Devices**: `waitForBootstrap()` accepts V2 as ready, init data fetched via V2 when V1 unavailable
- **Snapshots/Streams**: Use V2 snapshot endpoint and RTSPS stream API
- **Websockets**: V2 events WS handles motion/ring/smartDetectZone, V2 devices WS dispatches state changes
- **Settings UI**: V1 on top, V2 below marked as new, status page grouped by V1/V2/Access
- **Test button**: Tests V2 API key when no V1 credentials provided

## Not available in V2-only mode
Sirens, night vision mode, speaker volumes, recording mode, privacy zones, NFC/fingerprint user lookup — not part of the V2 Integration API.