### PR TITLE
feat: live camera widget via NVR snapshot proxy

### DIFF
--- a/app.json
+++ b/app.json
@@ -7168,11 +7168,12 @@
         {
           "id": "refreshInterval",
           "type": "number",
-          "value": 10,
-          "min": 5,
+          "value": 2,
+          "min": 1,
+          "max": 60,
           "title": {
-            "en": "Refresh interval (seconds)",
-            "nl": "Verversingsinterval (seconden)"
+            "en": "Refresh every (seconds)",
+            "nl": "Ververs elke (seconden)"
           }
         }
       ],
@@ -7180,6 +7181,10 @@
         "getSnapshotUrl": {
           "method": "GET",
           "path": "/"
+        },
+        "getSnapshot": {
+          "method": "GET",
+          "path": "/snapshot"
         }
       },
       "id": "camera"

--- a/widgets/camera/api.js
+++ b/widgets/camera/api.js
@@ -1,8 +1,9 @@
 'use strict';
 
+const https = require('https');
+
 module.exports = {
   async getSnapshotUrl({ homey, query }) {
-
     const { deviceId } = query;
 
     const driver = homey.drivers.getDriver('protectcamera');
@@ -16,5 +17,41 @@ module.exports = {
     }
 
     return device.cloudUrl ?? 'loading.png';
+  },
+
+  async getSnapshot({ homey, query }) {
+    const { deviceId } = query;
+
+    const webclient = homey.app.apiV2?.webclient;
+    if (!webclient?._serverHost) {
+      const driver = homey.drivers.getDriver('protectcamera');
+      const device = driver?.getUnifiDeviceById(deviceId);
+      return device?.cloudUrl ?? 'loading.png';
+    }
+
+    return new Promise((resolve, reject) => {
+      const req = https.request(
+        {
+          hostname: webclient._serverHost,
+          port: webclient._serverPort,
+          path: `/proxy/protect/integration/v1/cameras/${deviceId}/snapshot`,
+          method: 'GET',
+          headers: { 'X-API-KEY': webclient._apiToken },
+          rejectUnauthorized: false,
+        },
+        (res) => {
+          if (res.statusCode !== 200) {
+            res.resume();
+            return reject(new Error(`Snapshot fetch failed with status ${res.statusCode}`));
+          }
+          const chunks = [];
+          res.on('data', (chunk) => chunks.push(chunk));
+          res.on('end', () => resolve(`data:image/jpeg;base64,${Buffer.concat(chunks).toString('base64')}`));
+        },
+      );
+      req.setTimeout(5000, () => req.destroy(new Error('snapshot request timed out')));
+      req.on('error', reject);
+      req.end();
+    });
   },
 };

--- a/widgets/camera/api.js
+++ b/widgets/camera/api.js
@@ -20,10 +20,10 @@ module.exports = {
   },
 
   async getSnapshot({ homey, query }) {
-    const { deviceId } = query;
+    const { deviceId, live } = query;
 
     const webclient = homey.app.apiV2?.webclient;
-    if (!webclient?._serverHost) {
+    if (live !== 'true' || !webclient?._serverHost) {
       const driver = homey.drivers.getDriver('protectcamera');
       const device = driver?.getUnifiDeviceById(deviceId);
       return device?.cloudUrl ?? 'loading.png';

--- a/widgets/camera/public/index.html
+++ b/widgets/camera/public/index.html
@@ -34,7 +34,8 @@
                 return;
             }
             const start = Date.now();
-            Homey.api('GET', '/snapshot?deviceId=' + settings.device.id)
+            const live = settings.enableLiveSnapshot !== false;
+            Homey.api('GET', '/snapshot?deviceId=' + settings.device.id + '&live=' + live)
                 .then((dataUrl) => {
                     const img = document.getElementById('camera');
                     img.src = dataUrl;

--- a/widgets/camera/public/index.html
+++ b/widgets/camera/public/index.html
@@ -26,39 +26,25 @@
         Homey.ready();
 
         const settings = Homey.getSettings();
+        const interval = Math.max(1, settings.refreshInterval || 2) * 1000;
 
-        Homey.on('com.ubnt.unifiprotect.updateWidgetCamera', (...args) => {
-            console.log('updateWidgetImage event received with args:', args, settings.device.id);
-            if (args.deviceId && args.deviceId !== settings.device.id) return;
-            updateCamera(Homey, settings);
-        });
-
-        setInterval(() => {
-            updateCamera(Homey, settings);
-        }, settings.refreshInterval * 1000 || 5000); // Default to 5 seconds if not set
-
-        setTimeout(() => {
-            updateCamera(Homey, settings);
-        }, 1000); // Initial update after 1 second
-    }
-
-    function updateCamera(Homey, settings) {
-        if (settings.device.id) {
-            Homey.api('GET', '/?deviceId=' + settings.device.id)
-                .then((result) => {
-                    console.log('Received image URL:', result);
-                    if (result !== 'loading.png') {
-                        document.getElementById('camera').src = String(result) + '?t=' + new Date().getTime(); // Prevent caching
-                        document.getElementById('camera').className = 'camera';
-                    } else {
-                        document.getElementById('camera').src = String(result);
-                        document.getElementById('camera').className = 'loading';
-                    }
+        function poll() {
+            if (!settings.device?.id) {
+                setTimeout(poll, interval);
+                return;
+            }
+            const start = Date.now();
+            Homey.api('GET', '/snapshot?deviceId=' + settings.device.id)
+                .then((dataUrl) => {
+                    const img = document.getElementById('camera');
+                    img.src = dataUrl;
+                    img.className = 'camera';
                 })
-                .catch(console.error);
-        } else {
-            console.warn('No device ID found in settings.');
+                .catch(console.error)
+                .finally(() => setTimeout(poll, Math.max(0, interval - (Date.now() - start))));
         }
+
+        setTimeout(poll, 500);
     }
 </script>
 </body>

--- a/widgets/camera/widget.compose.json
+++ b/widgets/camera/widget.compose.json
@@ -16,11 +16,12 @@
     {
       "id": "refreshInterval",
       "type": "number",
-      "value": 10,
-      "min": 5,
+      "value": 2,
+      "min": 1,
+      "max": 60,
       "title": {
-        "en": "Refresh interval (seconds)",
-        "nl": "Verversingsinterval (seconden)"
+        "en": "Refresh every (seconds)",
+        "nl": "Ververs elke (seconden)"
       }
     }
   ],
@@ -28,6 +29,10 @@
     "getSnapshotUrl": {
       "method": "GET",
       "path": "/"
+    },
+    "getSnapshot": {
+      "method": "GET",
+      "path": "/snapshot"
     }
   }
 }

--- a/widgets/camera/widget.compose.json
+++ b/widgets/camera/widget.compose.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "id": "enableLiveSnapshot",
+      "type": "checkbox",
+      "value": true,
+      "title": {
+        "en": "Live snapshot (requires local network access)",
+        "nl": "Live snapshot (vereist lokaal netwerktoegang)"
+      }
+    },
+    {
       "id": "refreshInterval",
       "type": "number",
       "value": 2,


### PR DESCRIPTION
## Problem

The camera dashboard widget was permanently stale. The snapshot was fetched once at app init, stored on Homey's cloud, and the `cloudUrl` never changed. Polling the widget API returned the same image every time regardless of the configured refresh interval.

## Solution

Replace the `cloudUrl` approach with a server-side proxy: on every widget poll, `widgets/camera/api.js` fetches a fresh JPEG directly from the NVR (handling auth headers and self-signed TLS on the app side), and returns it as a base64 data URL to the widget.

## Changes

- **`widgets/camera/api.js`** — new `GET /snapshot` endpoint proxies a live JPEG from the NVR as a base64 data URL; 5s timeout prevents the widget freezing if a camera goes offline; falls back to `cloudUrl` if the v2 API is not yet initialised
- **`widgets/camera/public/index.html`** — replaced `setInterval` + `updateWidgetCamera` listener with start-time-based `setTimeout` chaining; next poll fires at `interval - elapsed` so the cycle time matches the setting regardless of NVR latency; errors keep the last frame rather than crashing the loop
- **`widgets/camera/widget.compose.json`** — refresh setting renamed to "Refresh every (seconds)", default 2s, min 1s, max 60s; new `/snapshot` API endpoint registered

## Notes

- The original `GET /` (`getSnapshotUrl`) endpoint is kept for backwards compatibility
- `updateWidgetCamera` realtime event was never emitted anywhere in the codebase; removing the listener is dead code cleanup
- Tested: `homey app validate --level publish` passes clean
- Not yet tested on physical Homey hardware — feedback welcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)