### PR TITLE
Fix smart audio detection events on the V2 API

### DIFF
--- a/library/SmartDetectionMixin.js
+++ b/library/SmartDetectionMixin.js
@@ -172,7 +172,7 @@ const SmartDetectionMixin = {
 
     this.homey.app.debug(`[AudioDetection] onAudioDetection ${JSON.stringify(event)}`);
 
-    const score = event.detectionScore;
+    const score = typeof event.detectionScore === 'number' ? event.detectionScore : 0;
     const audioDetectTypes = event.detectionTypes;
 
     if (audioDetectTypes && audioDetectTypes.length > 0) {

--- a/library/protect-api-v2/web-socket-events.js
+++ b/library/protect-api-v2/web-socket-events.js
@@ -213,6 +213,23 @@ class ProtectWebSocket extends BaseClass {
                     }
                 }
 
+                // Smart audio detection event - smartDetectTypes may be empty on initial 'add' and filled in on 'update'
+                if (itemType === 'smartAudioDetect') {
+                    this.homey.app.debug('[V2] smart audio detection: ' + JSON.stringify(item.smartDetectTypes || []) + ' on ' + deviceId);
+                    const payload = {
+                        smartDetectTypes: item.smartDetectTypes || [],
+                        start: item.start,
+                        end: item.end || null,
+                        score: item.score,
+                    };
+                    if (deviceCamera) {
+                        deviceCamera.onAudioDetection(payload, eventType, item.id);
+                    }
+                    if (deviceDoorbell) {
+                        deviceDoorbell.onAudioDetection(payload, eventType, item.id);
+                    }
+                }
+
             } catch (e) {
                 this.homey.app.debug('[V2 Events WS] dispatch error: ' + e);
             }


### PR DESCRIPTION
Problem

Smart audio detection (smartAudioDetect) was never handled by the V2 events websocket — only ring, motion and smartDetectZone were dispatched. As a result, anyone running standalone on the V2 API (without a V1 username/password) no longer received audio events.

Fix

	•	library/protect-api-v2/web-socket-events.js — smartAudioDetect items are now passed to onAudioDetection() for both camera and doorbell, matching the V1 implementation. This includes the add-with-empty-types → update-fills-types flow that the NVR uses.
	•	library/SmartDetectionMixin.js — the audio score now defaults to 0 when the V2 payload doesn’t provide a score. The visual smart-detection branch already did this; the audio branch passed undefined, causing the flow card to crash with Invalid value for token score. Expected number but got undefined.

Tested

Verified live on a Homey Pro running standalone on the V2 API. Event flow as observed:

add    → smartDetectTypes: []          → "waiting for update"
update → smartDetectTypes:["alrmSpeak"] → onAudioDetection → trigger ✓ (no error)


alrmSpeak events now fire the audio detection trigger without errors.