### PR TITLE
Trigger each smart/audio detection type once per detection event

### DIFF
--- a/library/Models/SmartDetectionEvent.js
+++ b/library/Models/SmartDetectionEvent.js
@@ -7,6 +7,8 @@ class SmartDetectionEvent {
     this.detectionTypes = detectionTypes;
     this.detectionScore = detectionScore;
     this.detectionEventId = detectionEventId;
+    // Types already triggered for this event, so each fires once (no flood).
+    this.triggered = new Set();
   }
 
 

--- a/library/SmartDetectionMixin.js
+++ b/library/SmartDetectionMixin.js
@@ -113,6 +113,11 @@ const SmartDetectionMixin = {
 
     if (smartDetectTypes.length > 0) {
       for (const type of smartDetectTypes) {
+        // Only trigger each type once per detection event (eventId).
+        if (event.triggered.has(type)) {
+          continue;
+        }
+        event.triggered.add(type);
         this.homey.app.debug('[SmartDetection] type=' + type + ' device=' + this.getData().id);
         if (type === 'person') {
           this.triggerSmartDetectionTriggerPerson(score, zones);
@@ -177,6 +182,11 @@ const SmartDetectionMixin = {
 
     if (audioDetectTypes && audioDetectTypes.length > 0) {
       for (const audioType of audioDetectTypes) {
+        // Only trigger each audio type once per detection event (eventId).
+        if (event.triggered.has(audioType)) {
+          continue;
+        }
+        event.triggered.add(audioType);
         this.homey.app.debug(`[AudioDetection] type=${audioType} device=${this.getData().id}`);
         const readableType = this.mapAudioDetectionType(audioType);
         this.triggerAudioDetectionTrigger(audioType, readableType, score);


### PR DESCRIPTION
Problem

For a single detection (same eventId), UniFi Protect sends a stream of update packets for as long as the subject stays in view. onSmartDetection and onAudioDetection fired their flow triggers again on every packet → flows get flooded. One person walking past fires the person trigger dozens of times.

Fix

Track per detection event which types have already fired a trigger, and skip those on subsequent updates. This way each type fires exactly once per eventId.

	•	A new detection gets a new eventId and fires fresh again (verified in the events: each separate event has a unique id + its own start).
	•	The last_smart_detection_score capability keeps updating on every packet, so the peak score is still captured — only the trigger fires once.
	•	The triggered Set is attached to the SmartDetectionEvent and is cleaned up together with the event by the existing cleanSmartDetectionEvents() sweep that runs every hour. No extra cleanup needed.

Behavior

person in view for 30s → ~20 update packets
   → 1× 'person' trigger
   → then 'face' appears → 1× 'face' trigger
new person → new eventId → fires again
